### PR TITLE
ScorePage前端

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -7,6 +7,7 @@ import HomePage from './pages/HomePage';
 import FriendListPage from './pages/Friend/FriendListPage';
 import AccountingPage from './pages/Accounting/AccountingPage';
 import './App.css';
+import ScorePage from './pages/ScorePage';
 
 const App: React.FC = () => {
   return (
@@ -18,6 +19,7 @@ const App: React.FC = () => {
         <Route path="/homepage" element={<HomePage />} />
         <Route path="/friendlist" element={<FriendListPage />} />
         <Route path="/accounting" element={<AccountingPage />} />
+        <Route path="/score" element={<ScorePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/client/src/pages/HomePage.tsx
+++ b/src/client/src/pages/HomePage.tsx
@@ -14,6 +14,9 @@ const HomePage: React.FC = () => {
         <button className="btn btn-warning" onClick={() => navigate('/accounting')}>
           分帳功能
         </button>
+        <button className="btn btn-primary" onClick={() => navigate('/score')}>
+          個人積分
+        </button>
       </div>
     </div>
   );

--- a/src/client/src/pages/ScorePage.tsx
+++ b/src/client/src/pages/ScorePage.tsx
@@ -1,0 +1,90 @@
+import React, { useState, useEffect } from 'react';
+
+const ScorePage: React.FC = () => {
+  const [myScore, setMyScore] = useState<number | null>(null); // 用戶的積分
+  const [leaderboard, setLeaderboard] = useState<{ name: string; credit_score: number }[]>([]); // 排行榜數據
+
+  // 獲取個人積分
+  const fetchMyScore = async () => {
+    try {
+      const response = await fetch('http://localhost:5000/user/1'); // 假設用戶 ID = 1
+      const data = await response.json();
+      if (data.success) {
+        setMyScore(data.data.credit_score);
+      } else {
+        alert('Failed to fetch your score');
+      }
+    } catch (error) {
+      console.error('Error fetching score:', error);
+      alert('Error fetching your score');
+    }
+  };
+
+  // 獲取排行榜
+  const fetchLeaderboard = async () => {
+    try {
+      const response = await fetch('http://localhost:5000/leaderboard');
+      const data = await response.json();
+      if (data.success) {
+        setLeaderboard(data.data);
+      } else {
+        alert('Failed to fetch leaderboard');
+      }
+    } catch (error) {
+      console.error('Error fetching leaderboard:', error);
+      alert('Error fetching leaderboard');
+    }
+  };
+
+  // 初始化數據
+  useEffect(() => {
+    fetchMyScore();
+    fetchLeaderboard();
+  }, []);
+
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h1>My Score</h1>
+      <p style={{ fontSize: '20px' }}>
+        Your current score is: <strong>{myScore !== null ? myScore : 'Loading...'}</strong>
+      </p>
+      <button
+        style={{
+          padding: '10px 20px',
+          fontSize: '16px',
+          color: '#fff',
+          backgroundColor: '#4CAF50',
+          border: 'none',
+          borderRadius: '5px',
+          cursor: 'pointer',
+          marginBottom: '20px',
+        }}
+        onClick={fetchMyScore}
+      >
+        Refresh Score
+      </button>
+
+      <h2>Leaderboard</h2>
+      <table style={{ margin: '0 auto', borderCollapse: 'collapse', width: '50%' }}>
+        <thead>
+          <tr>
+            <th style={{ border: '1px solid #ddd', padding: '8px' }}>Rank</th>
+            <th style={{ border: '1px solid #ddd', padding: '8px' }}>Name</th>
+            <th style={{ border: '1px solid #ddd', padding: '8px' }}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {leaderboard.map((entry, index) => (
+            <tr key={index}>
+              <td style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'center' }}>{index + 1}</td>
+              <td style={{ border: '1px solid #ddd', padding: '8px' }}>{entry.name}</td>
+              <td style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'center' }}>{entry.credit_score}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ScorePage;


### PR DESCRIPTION
### 🎯 **標題:**

1. **新增 ScorePage 前端**
2. **新增 HomePage 中 ScorePage**
---

### 🎯 **描述:**

此 PR 包括以下變更：

1. **新增 ScorePage.tsx**：
   - 在 `client/src/pages` 中建立了新的 `ScorePage.tsx` 。
   - 新增顯示用戶分數及排行榜的功能。
   - 添加了一個佔位的刷新按鈕，預留之後 API 整合。

2. **更新 App.tsx**：
   - 在 `App.tsx` 中新增了 `ScorePage` 的路由配置。
   - 設定路徑 `/score` 渲染 `ScorePage`。

3. **修改 Homepage**：
   - 在首頁新增一個按鈕，提供跳轉到 `ScorePage` 的功能。

---

### 🎯 **測試:**

1. 手動測試路由：
   - 驗證從 `/homepage` 成功跳轉到 `/score`。
   - 確認 `ScorePage` 正常渲染。

2. 界面驗證：
   - 檢查desktop的佈局與樣式。

---

### 🎯 **影響範圍:**

- 影響以下檔案：
  - `client/src/pages/ScorePage.tsx`
  - `client/src/App.tsx`
  - `client/src/pages/HomePage.tsx`

- 新增路由 `/score`。

---

### 🎯 **檢查清單:**

- [x] 新增 `ScorePage.tsx` 元件。
- [x] 更新 `App.tsx` 中的路由。
- [x] 在首頁新增跳轉按鈕。
- [ ] 整合排行榜的後端 API（待完成）。

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `/score` route to the application
  - Implemented a personal score page with user score and leaderboard functionality
  - Added a button on the home page to navigate to the score page

- **User Experience**
  - Users can now view their personal score
  - Leaderboard display with user credit scores
  - Option to refresh personal score

<!-- end of auto-generated comment: release notes by coderabbit.ai -->